### PR TITLE
Improvements for mass mapping methods and starlet transform

### DIFF
--- a/examples/mcalens_paper/make_fig.py
+++ b/examples/mcalens_paper/make_fig.py
@@ -1,1 +1,603 @@
-#! /usr/bin/env Python'''Created on Sept 10 2020@authors: Jean-Luc Starck   '''# To run this experiment,the COSMOSTAT package has to be installed. Note that CosmoStat installation# automatically installs the LENSPACK package.# The used C++ code is in CosmoStat (to compute power spectra and spherical mass mapping)# The python 2D mass mapping code  is in LensPack.## !!!        Make sure the git folder cosmostat/build/bin is in your user path.import osimport numpy as npfrom astropy.io import fitsfrom scipy import ndimagefrom scipy.ndimage.filters import gaussian_filter as gfimport mathimport matplotlib.pyplot as pltimport astropyimport pylabfrom os import removefrom subprocess import check_callfrom datetime import datetimeimport matplotlibfrom subprocess import check_callimport readlinefrom mpl_toolkits.axes_grid1 import make_axes_locatablefrom pysap.extensions import sparse2dimport pyqtgraphfrom pyqtgraph.Qt import QtGuiimport numpy as npfrom numpy import linalg as LAfrom sys import getsizeofimport scipyfrom scipy.special import erffrom scipy import ndimagefrom scipy.optimize import curve_fit# GITHUB Cosmostat: cosmostat packageimport pycs as psimport pycsfrom pycs.sparsity.sparse2d.starlet import *from pycs.misc.cosmostat_init import *from pycs.misc.mr_prog import *from pycs.misc.utilHSS import *from pycs.misc.im1d_tend import *from pycs.misc.stats import *from pycs.sparsity.sparse2d.dct import dct2d, idct2dfrom pycs.sparsity.sparse2d.dct_inpainting import dct_inpaintingimport pycs.sparsity.sparse2d.starletfrom pycs.sparsity.mrs.mrs_tools import *import lenspackfrom lenspack.image.mass_mapping import *from lenspack.geometry.projections import gnomfrom pycs.astro.wl.lenspack.image.mass_mapping import *# from pycs.astro.wl.lenspack.geometry.projections import gnomimport footprintfrom footprint import draw_footprintfrom pycs.misc.im_isospec import *# Function for drawing the data footprintcosmos_vertices = np.load("footprint.npy")def draw_footprint(ax, c='w', lw=1, **kwargs):    ra, dec = cosmos_vertices.T    ax.plot(ra, dec, c=c, lw=lw, **kwargs)# lut='inferno'# lut='gist_stern'# lut='magma'DEF_lut='inferno'    def mp(x, a, u, ns, c):    if ns ==0:        ux=1.    else:        ux=(u*x)**(-abs(ns))    ret=np.exp(abs(a * ux)) +  c    return ret#  #  popt, pcov = curve_fit(mp,xz,pke[1:])#  plot(xz, mp(xz,*popt))# https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html# This routine needs the cosmostat binary im_isospec# it returns the estimated noisy kappa power spectrum and a polynomial# fit to have a noise free estimationdef estimate_pk(d,M,pn):    # Make an iterative Kaiser-Squires reconstruction with inpainting    ksi = M.iks(d.g1,d.g2,d.mask)    # calculate the radial power spectrum    pksi = im_isospec(ksi.real)        #         # p = pksi - pn        # pef=mr_prog(pe, prog="mr1d_filter -m8 -P -s5")        # denoise the estimated noise theoretical powewr spectrum        # pkef=mr_prog(pke, prog="mr1d_filter -F4 -n6 -s5 -t7 -m5 ")    pke,pkb,Pun = M.get_theo_kappa_power_spectum(d, PowSpecNoise=pn, FirstFreqNoNoise=1)    pen=np.copy(pke)    xz=np.arange(pke.size)    popt, pcov = curve_fit(mp,xz[3:],pksi[3:], method='trf')    pf = mp(xz[1:],*popt)    pke[1:]=pf    pke[0]=0.    pke=pke-pn    pke[pke < 0] = 0    # pixel window apodization,  assuming a window function of Fwhm=2 pixels,    di=d.g1 * 0    di[128,128]=1.    dis=M.smooth(di,sigma=0.85)  # 0.85 =     pdis=im_isospec(dis) * 256.**2    pke = pke*pdis    return pen,pke    def get_rms_error(Res, TrueSol, Mask, sigma=0):    if sigma > 0:        Resi = smooth2d(TrueSol - Res, sigma) * Mask        TS = smooth2d(TrueSol, sigma) * Mask    else:        Resi = (TrueSol - Res) * Mask        TS = TrueSol * Mask    ind = np.where(Mask != 0)    Resi[ind] = Resi[ind] - np.mean(Resi[ind])    TS[ind] = TS[ind] - np.mean(TS[ind])    Err =  LA.norm(Resi) / LA.norm(TrueSol*Mask) * 100.    return Errdef make_fig_exp_wiener(lut=DEF_lut):    # For space constraints, we provide this experiment starting from a pixelized     # shear map, and not from the catalog.       # Read shear data and covariance matrix    g1 = readfits('exp_wiener_miceDSV_g1.fits')    g2 = readfits('exp_wiener_miceDSV_g2.fits')    Ncov = readfits('exp_wiener_miceDSV_covmat.fits')    # Read the true convergence map and its theoretical power spectrum    ktr = readfits('exp_wiener_miceDSV_true_convergence_map.fits')    ps1d = readfits('exp_wiener_miceDSV_signal_powspec.fits')        # Mass mapping class initialization    (nx,ny) = Ncov.shape     M = massmap2d(name='mass')    M.init_massmap(nx,ny)    M.DEF_niter=200    Inpaint=False    M.niter_debias=30    M.Verbose=False                # Read the noise power spectrum. It has been derived from     # from the covariance matrix using 1000 realization with the command:    #    Pn = M.get_noise_powspec(Ncov ,mask=mask,nsimu=1000, inpaint=True)    pn = readfits('exp_wiener_miceDSV_noise_powspec.fits')    # derive the mask from the covariance matrix    index = np.where(Ncov<1e2)    mask = np.zeros((nx,ny))    mask[index] = 1    ind = np.where(mask != 1)    mask[ind]=0        # Shear data class initialization    d=shear_data()    d.g1=g1    d.g2=g2    d.Ncov =Ncov    d.mask = mask        # make Fig. 8 of MCAlens paper    tvilut(mask,title='DES-MICE Mask', lut=lut,filename='fig_mice_mask.png', vmin=0, vmax=1)    tvilut(smooth2d(ktr, 1.)*mask,title='Convergence map', lut=lut,filename='fig_mice_kappa.png', vmin=-0.03,vmax=0.03)    tvilut(g1,title='g1', lut=lut,filename='fig_mice_g1.png', vmin=-0.3,vmax=0.3)    tvilut(g2,title='g2', lut=lut,filename='fig_mice_g2.png', vmin=-0.3,vmax=0.3)    # Wiener filtering using the theoretical power spectrum    # exemple of wiener routine, without using the iterative prox.    # this is not shown in the MCAlens paper    kw,wi = M.wiener(g1, g2, ps1d, pn)          # Proximal iterative filtering.     ke_pwiener,kb_pwiener = M.prox_wiener_filtering(g1, g2, ps1d, Ncov, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)    #  Proximal iterative filtering with Inpainting    ke_inp_pwiener,kb_winp = M.prox_wiener_filtering(g1, g2, ps1d, Ncov, Pn=pn, Inpaint=True) #, Pn=Pn) # ,ktr=InShearData.ktr)    # make Fig. 9 of MCAlens paper    tvilut(ke_pwiener,title='Wiener', lut=lut,filename='fig_mice_wiener.png', vmin=-0.004,vmax=0.004)    tvilut(ke_inp_pwiener,title='Inpainted Wiener', lut=lut,filename='fig_mice_inp_wiener.png', vmin=-0.004,vmax=0.004)    # agnostic wiener filtering    # estimate a noisy power spectrum     # pen,pke = estimate_pk(d,M,pn)    pen = readfits('exp_wiener_miceDSV_estimated_noisy.fits')    pke = readfits('exp_wiener_miceDSV_estimated_theoretical_pk.fits')    kiwa,iwi = M.prox_wiener_filtering(g1, g2, pke, Ncov, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)    plt.figure()    s=0    plt.plot(pen,'blue', label='PowSpec(KappaE) - Pn')    plt.plot(pke, color='red', label='Fit')    plt.plot(ps1d,color='black', label='True Pk power spectrum')     plt.legend(loc='upper right')    plt.savefig('fig_plot_mice_pk.png')    plt.show()           # Example of error calculation at a give scale    sig=2    print("== ERROR Sigma = ", sig)    ks =  M.gamma_to_cf_kappa(g1,g2)     ks = ks.real    Err_ks = get_rms_error(ks, ktr,mask,sigma=sig)          print("   Kaiser Squires Error: ", Err_ks)    Err_kiw = get_rms_error(ke_pwiener,ktr,mask,sigma=sig)     print("   Iterative Wiener Error: ", Err_kiw)    Err_kiwa = get_rms_error(kiwa,ktr,mask,sigma=sig)     print("   Agnostic Iterative Wiener Error: ", Err_kiwa)def make_fig_exp_ramses(lut=DEF_lut):        D = shear_data()    D.Ncov = readfits('exp_wiener_miceDSV_covmat.fits')     newInputSimu = readfits('exp_ramses_true_convergence_map.fits')    (nx,ny) = D.Ncov.shape # assume a diagonal cov mat    D.nx = nx    D.ny = ny    M = massmap2d(name='mass')    M.init_massmap(D.nx,D.ny)    M.DEF_niter=100    Bmode=True    Inpaint=False    index = np.where(D.Ncov<1e2)    D.mask = np.zeros((nx,ny))    D.mask[index] = 1    mask=D.mask    n1,n2 = D.get_shear_noise()    nxin,nyin = newInputSimu.shape    depx= (nxin-nx)//2    depy= (nyin-ny) //2    D.ktr= newInputSimu[depx:depx+nx,depy:depy+ny]        Minput = massmap2d(name='mass')    Minput.init_massmap(nxin,nyin)      (g1t,g2t) = Minput.kappa_to_gamma(newInputSimu)     D.g1t = g1t[depx:depx+nx,depy:depy+ny]    D.g2t = g2t[depx:depx+nx,depy:depy+ny]    pk = im_isospec(D.ktr)    D.ps1d = pk    D.g1 = (D.g1t + n1) * D.mask    D.g2 = (D.g2t + n2) * D.mask        # Compute the MCAlens solution    M.Verbose=False    k1r5,k1i,k2r5,k2i = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Inpaint=Inpaint, Bmode=Bmode, InpNiter=20)    # info(D.ktr-k1r5)        # Propate noise realization to get a rms map    run_sim1=0    if run_sim1:        Nsimu=100        TabSim = np.zeros([Nsimu,nx,ny])        for i in range(Nsimu):            print("SIMU ",i+1)            nk1r5,nk1i,nk2r5,nk2i5 = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Bmode=Bmode, PropagateNoise=True)            TabSim[i,:,:]=nk1r5        rms = TabSim.std(0)        writefits('exp_ramses_mcalens_rms.fits',rms)    else:        rms = readfits("exp_ramses_mcalens_rms.fits")        # make Fig.2 of MCAlens paper    vm=0.2    vmin=-0.1    tvilut(D.ktr*mask,title='True kappa map',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_kt.png')    tvilut(k1r5*mask, title='MCAlens',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_mcalens_sig5_masked.png')    tvilut((k1r5-k2r5)*mask, title='MCAlens-Gaussian Component',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_mcalens_gaussian_sig5_masked.png')    tvilut(k2r5*mask, title='MCAlens-Sparse Component',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_mcalens_sparse_sig5_masked.png')    # make Fig.3 of MCAlens paper    tvilut(rms*mask,title='MCAlens RMS Map',fs=5, lut=lut, filename='fig_ramses_mcalens_rms.png')    tvilut(np.abs(k1r5/rms*mask),title='MCAlens SNR Map',fs=5, lut=lut, vmax=10,filename='fig_ramses_mcalens_snr.png')    tvilut(M.WT_ActiveCoef.sum(0), title='Active WT Coef Mask',fs=5, lut=lut, filename='fig_ramses_mcalens_sig5_act_coef_support.png')def make_fig_exp_columbia(lut=DEF_lut):            D = shear_data()    cov_mice = readfits('exp_wiener_miceDSV_covmat.fits')     newInputSimu = readfits('exp_colombia_true_convergence_map.fits')    D.ktr=newInputSimu    ResolPixel=0.8  # the orignal image has been rebinned by a factor 2    # MICE cov mat = 10 Euclid noise    # mice resol = 4.5    # Colombia resol = 0.8         # cov_columbia = cov_mice / 10 *  area_mice / area_jia    # ==>  4.5**2 / 0.8**2 /10 = 3.16    ScaleToEuclidNoise=3.16    D.Ncov = cov_mice * ScaleToEuclidNoise    (nx,ny) = D.Ncov.shape # assume a diagonal cov mat    D.nx = nx    D.ny = ny    index = np.where(D.Ncov<1e2)    D.mask = np.zeros((nx,ny))    D.mask[index] = 1    mask=D.mask    n1,n2 = D.get_shear_noise()    FirstRun=False    if FirstRun:        pn = M.get_noise_powspec(D.Ncov ,mask=D.mask,nsimu=1000, inpaint=True)        writefits("exp_colombia_noise_powspec.fits", pn)        FirstRun=False    else:        pn = readfits("exp_colombia_noise_powspec.fits")    M = massmap2d(name='mass')    M.init_massmap(D.nx,D.ny)    M.DEF_niter=100    Bmode=True    Inpaint=False        (g1t,g2t) = M.kappa_to_gamma(D.ktr)     D.g1t = g1t     D.g2t = g2t     pk = im_isospec(D.ktr)    D.ps1d = pk    D.g1 = (D.g1t + n1) * D.mask    D.g2 = (D.g2t + n2) * D.mask        # Compute the MCAlens solution    M.Verbose=False    k1r5,k1i,k2r5,k2i = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Inpaint=Inpaint, Bmode=Bmode, InpNiter=20)    # info(D.ktr-k1r5)    kiw,iwi = M.prox_wiener_filtering(D.g1, D.g2, D.ps1d, D.Ncov, Inpaint=Inpaint, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)    ks =  M.g2k(D.g1,D.g2)     Sigma2Fwhm = 2.355    sig=2.    ks2=smooth2d(ks, 2.) * mask # Resol = ResolPixel * Sigma2Fwhm * sig = 3.8 amin    # Propate noise realization to get a rms map    run_sim1=0    if run_sim1:        Nsimu=100        TabSim = np.zeros([Nsimu,nx,ny])        for i in range(Nsimu):            print("SIMU ",i+1)            nk1r5,nk1i,nk2r5,nk2i5 = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Bmode=Bmode, PropagateNoise=True)            TabSim[i,:,:]=nk1r5        rms = TabSim.std(0)        writefits('exp_columbia_mcalens_rms.fits',rms)    else:        rms = readfits("exp_columbia_mcalens_rms.fits")    vm=0.1    vmin=-0.1    # make Fig.5 of MCAlens paper    tvilut(D.ktr*mask,title='True kappa map',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_kt.png')    tvilut(kiw*mask, title='Wiener',fs=5, vmin=-0.02, vmax=0.02,lut=lut, filename='fig_jia_wiener.png')    tvilut(ks2,title='KS (Fwhm=3.8 arcmin)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_ks2.png')    tvilut(k1r5*mask, title='MCAlens (lambda=5)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_mcalens_sig5.png')    tvilut((k1r5-k2r5)*mask, title='MCAlens-Gaussian Component (lambda=5)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_mcalens_xw_sig5.png')    tvilut(k2r5*mask, title='MCAlens-Sparse Component (lambda=5)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_mcalens_xs_sig5.png')    tvilut(rms*mask,title='MCAlens RMS Map',fs=5, lut=lut, filename='fig_jia_mcalens_rms.png')    tvilut(np.abs(k1r5/rms*mask),title='MCAlens SNR Map',fs=5, lut=lut, filename='fig_jia_mcalens_snr.png')    tvilut(M.WT_ActiveCoef.sum(0), title='Active WT Coef Mask', lut=lut,fs=5, filename='fig_jia_mcalens_sig5_act_coef_support.png')# Routine for COSMOS EXPERIMENTdef get_extend_radec():    ra0, dec0 = (150.11, 2.24) # from cosmos.astro.caltech.edu (could also just use the medians of positions)    proj = gnom.projector(ra0, dec0)    dx = np.deg2rad(1.5) / 2. # 1.5 degrees across    dy = dx    extent_xy = [-dx, dx, -dy, dy]    ra_min, dec_min = proj.xy2radec(-dx, -dy)    ra_max, dec_max = proj.xy2radec(dx, dy)    extent_radec = [ra_min, ra_max, dec_min, dec_max]    return extent_radec    def tvradec(ima, title='ima',vmin=None,vmax=None,smooth=None,xclus=False,mtext=False,m500min=0, zmin=0.3,zmax=1,ztext=False,lut=DEF_lut,filename=None,extent_radec=None):    if extent_radec is None:        extent_radec = get_extend_radec()    fs = 18 # fontsize            fig, ax = plt.subplots(1, 1, figsize=(10, 8))    # Kappa map    if smooth is None:        imaS = ima    else:        imaS = gf(ima, smooth)    img = ax.imshow(imaS, origin='lower', cmap=lut, vmin=vmin, vmax=vmax, extent=extent_radec)    draw_footprint(ax)        # Xray clusters    if xclus:        xclusters = np.loadtxt("xray.txt")        highz = (xclusters[:, 6] >= zmin) & (xclusters[:, 6] <= zmax)        for cluster in xclusters[highz]:            ra_cl, dec_cl, z_cl = cluster[1], cluster[2], cluster[6]            m500 = cluster[7]            if m500 > m500min:                ax.scatter(ra_cl, dec_cl, c='w', s=12)                if ztext:                    ax.text(ra_cl + 0.03, dec_cl + 0.02, "{:.2f}".format(z_cl), fontsize=8, c='w')                if mtext:                    ax.text(ra_cl + 0.03, dec_cl - 0.02, "{:.2f}".format(m500), fontsize=8, c='w')    # Clean up and decorate    ax.set_aspect('equal')    ax.set_xlim(ax.get_xlim()[::-1])    ax.set_title(title, fontsize=fs)    ax.set_xlabel("RA [deg]", fontsize=fs)    ax.set_ylabel("Dec [deg]", fontsize=fs)    fig.colorbar(img, ax=ax)    if filename is not None:        plt.savefig(filename)def tvglimpse(mask=None,vmin=0,vmax=0.04,xclus=False, lut=DEF_lut, mtext=False,m500min=0, zmin=0.3,zmax=1,ztext=False,filename=None):    hdulist = fits.open('cosmos_bright_lambda3.0_niter1000_debias1000.fits')    kappa, ra, dec = [hdu.data for hdu in hdulist]    if mask is not None:        kappa *= mask        fs = 18 # fontsize            # Determine glimpse RA/Dec extent (not perfect !)    ra_min_gl = np.mean([ra[0][0], ra[-1][0]])    ra_max_gl = np.mean([ra[0][-1], ra[-1][-1]])    dec_min_gl = np.mean([dec[0][0], dec[0][-1]])    dec_max_gl = np.mean([dec[-1][0], dec[-1][-1]])    extent_glimpse = [ra_min_gl, ra_max_gl, dec_min_gl, dec_max_gl]    # extent_glimpse = [149.04680898212678,151.17319101787328,1.1774193776516106,3.3018101267642783]        fig, ax = plt.subplots(1, 1, figsize=(10, 8))    img = ax.imshow(kappa, origin='lower', cmap=lut, vmax=0.1, extent=extent_glimpse)    draw_footprint(ax)    # Plot xray clusters    if xclus:        xclusters = np.loadtxt("xray.txt")        highz = (xclusters[:, 6] >= zmin) & (xclusters[:, 6] <= zmax)        for cluster in xclusters[highz]:            ra_cl, dec_cl, z_cl = cluster[1], cluster[2], cluster[6]            m500 = cluster[7]            if m500 > m500min:                ax.scatter(ra_cl, dec_cl, c='w', s=12)                if ztext:                    ax.text(ra_cl + 0.03, dec_cl + 0.02, "{:.2f}".format(z_cl), fontsize=8, c='w')                if mtext:                    ax.text(ra_cl + 0.03, dec_cl - 0.02, "{:.2f}".format(m500), fontsize=8, c='w')                # Clean up and decorate    extent_radec = get_extend_radec()    ax.set_aspect('equal')    ax.set_title("Glimpse2D ($\lambda=3.0$)", fontsize=fs)    ax.set_xlabel("RA [deg]", fontsize=fs)    ax.set_ylabel("Dec [deg]", fontsize=fs)    # ax.set_xlim(149.25, 151)    # ax.set_ylim(1.375, 3.125)    ax.set_xlim(extent_radec[:2])    ax.set_ylim(extent_radec[2:])    ax.set_xlim(ax.get_xlim()[::-1])    fig.colorbar(img, ax=ax)    if filename is not None:        plt.savefig(filename)    def make_fig_exp_cosmos(lut=DEF_lut, WriteRes=False):    # Using bright galaxy catalog, we got these 2 binned shear images    e1map = readfits('cosmos_g1.fits')    e2map = readfits('cosmos_g2.fits')    galmap = readfits('cosmos_countmap.fits')    ps1d = readfits('cosmos_estimated_signal_powspec.fits')    pn = readfits('cosmos_estimated_noise_powspec.fits')        # Kaiser-Squires inversion    # kE, kB = ks93(e1map, e2map)    D = shear_data()    D.g1 = e1map    D.g2 = e2map     SigmaNoise=0.28    (nx,ny) = e1map.shape # assume a diagonal cov mat    ind = np.where(galmap >  0 )    D.mask = np.zeros((nx,ny))    D.mask[ind] = 1    Ncov=np.zeros((nx,ny))    Ncov[ind] = 2. * SigmaNoise**2 / galmap[ind]    Ncov[Ncov==0] = 1e9    D.Ncov = Ncov    D.nx = nx    D.ny = ny    FNsuf = "_db"    M = massmap2d(name='mass')    M.init_massmap(D.nx,D.ny)      M.DEF_niter=100    Inpaint=False    Bmode=True    g1=D.g1    g2=D.g2    ks =  M.g2k(g1,g2)     ks2 = M.smooth(ks, sigma=2)    kiw,iwi = M.prox_wiener_filtering(D.g1, D.g2, ps1d, D.Ncov, Inpaint=Inpaint, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)    k1r5,k1i5,k2r5,k2i = M.sparse_wiener_filtering(D, ps1d, Nsigma=5, Inpaint=Inpaint, Bmode=Bmode, ktr=None)        vmin=-0.03    vmax=0.1    zmax=0.99    m500min=3    mtext=False # overplot x-clusters M500    ztext=True # overplot x-clusters redshift    Sigma2Fwhm = 2.355    smooth= 1.2 / Sigma2Fwhm   # resolution in Massey 07 paper    xclus=True # True to overplot x-clusters    FN5="fig_cosmos"+FNsuf+"_mcalens_5sigma.png"    m=D.mask        FN="fig_cosmos" + FNsuf + "_" + "galmap" + ".png"    tvradec(galmap, 'Galaxy number count',lut=lut,filename=FN)    FNW="fig_cosmos"+FNsuf+"_wiener.png"    tvradec(kiw*m, title='Wiener',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=-0.01,vmax=0.02,zmax=zmax, smooth=smooth,ztext=ztext,filename=FNW)    FN="fig_cosmos"+FNsuf+"_ks2.png"    s2=1.2 / Sigma2Fwhm * 2.    tvradec(ks2, title='KS (FWHM=2.4arcmin)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=s2,ztext=ztext,filename=FN)    FNG="fig_cosmos"+FNsuf+"_glimpse.png"    tvglimpse(mask=m, vmin=vmin,vmax=vmax,xclus=xclus,lut=lut, mtext=mtext,m500min=m500min,zmax=zmax,ztext=ztext,filename=FNG)    tvradec(k1r5*m, title='MCALens (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN5)    # FN5="fig_cosmos"+FNsuf+"_mcalens_5sigma_xs.png"    #tvradec(k2r5*m, title='MCALens-Gaussian Component  (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN5)    #FN5="fig_cosmos"+FNsuf+"_mcalens_5sigma_xw.png"    #tvradec((k1r5-k2r5)*m, title='MCALens-Gaussian Component (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN5)    FN="fig_cosmos"+FNsuf+"_mcalens_5sigma_bmode.png"    tvradec(k1i5, title='B-mode (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN)        def make_fig_exp_sphere(lut=DEF_lut):    dpi=100    k = mrs_read("exp_sphere_mice_kappa.fits")    nside=hp.get_nside(k)    print("Nside = ", nside)    print("Resol pixel (arcmin)= ", hp.nside2resol(nside, arcmin=True))        g1 = mrs_read("exp_sphere_mice_g1_noisy.fits")    g2 = mrs_read("exp_sphere_mice_g2_noisy.fits")    # k0p5 = hp.smoothing(k, sigma=0.5/360. * (np.pi*2),pol=False)    k1 = hp.smoothing(k, sigma=1./360. * (np.pi*2),pol=False)    # k2 = hp.smoothing(k, sigma=2./360. * (np.pi*2),pol=False)    k3 = hp.smoothing(k, sigma=3./360. * (np.pi*2),pol=False)    hp.mollview(k1,title='Simulated kappa map (1 degree)', cmap=lut)    plt.savefig('fig_sphere_mice_input_1deg.png', dpi=dpi)    hp.mollview(k3,title='Simulated kappa map (3 degrees)', cmap=lut)    plt.savefig('fig_sphere_mice_input_3deg.png', dpi=dpi)    #hp.mollview(k0p5,title='Simulated kappa map (0.5 degree)', cmap=lut)    #plt.savefig('fig_sphere_mice_input_0.5deg.png', dpi=dpi)    #hp.mollview(k2,title='Simulated kappa map (2 degrees)', cmap=lut)    #plt.savefig('fig_sphere_mice_input_2deg.png', dpi=dpi)            FirstRun=0    if FirstRun:        cmd="wls_mcalens -F2 -i200 -N exp_sphere_covmat.fits -v -s5 -n5  -m4 -S exp_sphere_mice_kappa_cl.fits exp_sphere_mice_g1_noisy.fits exp_sphere_mice_g2_noisy.fits  res_mice_200"        args = shlex.split(cmd)        call(args)    x1 = mrs_read('res_mice_200_e.fits')    xs1 = mrs_read('res_mice_200_sparse_e.fits')    x11 = hp.smoothing(xs1, sigma=1./360. * (np.pi*2),pol=False)        hp.mollview(x11,title='MCALens: sparse component (1 degree)', cmap=lut)    plt.savefig('fig_sphere_mice_mcalens_sparse.png', dpi=dpi)        hp.mollview(x1-xs1,title='MCALens: Wiener component', cmap=lut)    plt.savefig('fig_sphere_mice_mcalens_wiener.png', dpi=dpi)def make_all_figs(lut='magma'):    make_fig_exp_wiener(lut=lut)    make_fig_exp_columbia(lut=lut)    make_fig_exp_ramses(lut=lut)    make_fig_exp_cosmos(lut=lut)    make_fig_exp_sphere(lut=lut)lut=DEF_lutmake_all_figs(lut=lut)
+#! /usr/bin/env Python
+'''
+Created on Sept 10 2020
+
+@authors: Jean-Luc Starck   
+'''
+# To run this experiment,the COSMOSTAT package has to be installed. Note that CosmoStat installation
+# automatically installs the LENSPACK package.
+# The used C++ code is in CosmoStat (to compute power spectra and spherical mass mapping)
+# The python 2D mass mapping code  is in LensPack.
+#
+# !!!        Make sure the git folder cosmostat/build/bin is in your user path.
+
+import os
+import numpy as np
+from astropy.io import fits
+from scipy import ndimage
+import math
+import matplotlib.pyplot as plt
+import astropy
+import pylab
+from os import remove
+from subprocess import check_call
+from datetime import datetime
+import matplotlib
+from subprocess import check_call
+import readline
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from pysap.extensions import sparse2d
+import pyqtgraph
+from pyqtgraph.Qt import QtGui
+import numpy as np
+from numpy import linalg as LA
+from sys import getsizeof
+import scipy
+from scipy.special import erf
+from scipy import ndimage
+from scipy.optimize import curve_fit
+
+# GITHUB Cosmostat: cosmostat package
+import pycs as ps
+import pycs
+from pycs.sparsity.sparse2d.starlet import *
+from pycs.misc.cosmostat_init import *
+from pycs.misc.mr_prog import *
+from pycs.misc.utilHSS import *
+from pycs.misc.im1d_tend import *
+from pycs.misc.stats import *
+from pycs.sparsity.sparse2d.dct import dct2d, idct2d
+from pycs.sparsity.sparse2d.dct_inpainting import dct_inpainting
+import pycs.sparsity.sparse2d.starlet
+from pycs.sparsity.mrs.mrs_tools import *
+
+import lenspack
+from lenspack.image.mass_mapping import *
+from lenspack.geometry.projections import gnom
+
+from pycs.astro.wl.lenspack.image.mass_mapping import *
+# from pycs.astro.wl.lenspack.geometry.projections import gnom
+import footprint
+from footprint import draw_footprint
+from pycs.misc.im_isospec import *
+
+# Function for drawing the data footprint
+cosmos_vertices = np.load("footprint.npy")
+
+def draw_footprint(ax, c='w', lw=1, **kwargs):
+    ra, dec = cosmos_vertices.T
+    ax.plot(ra, dec, c=c, lw=lw, **kwargs)
+
+# lut='inferno'
+# lut='gist_stern'
+# lut='magma'
+
+DEF_lut='inferno'
+    
+def mp(x, a, u, ns, c):
+    if ns ==0:
+        ux=1.
+    else:
+        ux=(u*x)**(-abs(ns))
+    ret=np.exp(abs(a * ux)) +  c
+    return ret
+#  
+#  popt, pcov = curve_fit(mp,xz,pke[1:])
+#  plot(xz, mp(xz,*popt))
+# https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html
+
+# This routine needs the cosmostat binary im_isospec
+# it returns the estimated noisy kappa power spectrum and a polynomial
+# fit to have a noise free estimation
+def estimate_pk(d,M,pn):
+    # Make an iterative Kaiser-Squires reconstruction with inpainting
+    ksi = M.iks(d.g1,d.g2,d.mask)
+    # calculate the radial power spectrum
+    pksi = im_isospec(ksi.real)
+        # 
+        # p = pksi - pn
+        # pef=mr_prog(pe, prog="mr1d_filter -m8 -P -s5")
+        # denoise the estimated noise theoretical powewr spectrum
+        # pkef=mr_prog(pke, prog="mr1d_filter -F4 -n6 -s5 -t7 -m5 ")
+    pke,pkb,Pun = M.get_theo_kappa_power_spectum(d, PowSpecNoise=pn, FirstFreqNoNoise=1)
+    pen=np.copy(pke)
+    xz=np.arange(pke.size)
+    popt, pcov = curve_fit(mp,xz[3:],pksi[3:], method='trf')
+    pf = mp(xz[1:],*popt)
+    pke[1:]=pf
+    pke[0]=0.
+    pke=pke-pn
+    pke[pke < 0] = 0
+    # pixel window apodization,  assuming a window function of Fwhm=2 pixels,
+    di=d.g1 * 0
+    di[128,128]=1.
+    dis=M.smooth(di,sigma=0.85)  # 0.85 = 
+    pdis=im_isospec(dis) * 256.**2
+    pke = pke*pdis
+    return pen,pke
+    
+def get_rms_error(Res, TrueSol, Mask, sigma=0):
+    if sigma > 0:
+        Resi = smooth2d(TrueSol - Res, sigma) * Mask
+        TS = smooth2d(TrueSol, sigma) * Mask
+    else:
+        Resi = (TrueSol - Res) * Mask
+        TS = TrueSol * Mask
+    ind = np.where(Mask != 0)
+    Resi[ind] = Resi[ind] - np.mean(Resi[ind])
+    TS[ind] = TS[ind] - np.mean(TS[ind])
+    Err =  LA.norm(Resi) / LA.norm(TrueSol*Mask) * 100.
+    return Err
+
+
+def make_fig_exp_wiener(lut=DEF_lut):
+
+    # For space constraints, we provide this experiment starting from a pixelized 
+    # shear map, and not from the catalog.   
+
+    # Read shear data and covariance matrix
+    g1 = readfits('exp_wiener_miceDSV_g1.fits')
+    g2 = readfits('exp_wiener_miceDSV_g2.fits')
+    Ncov = readfits('exp_wiener_miceDSV_covmat.fits')
+
+    # Read the true convergence map and its theoretical power spectrum
+    ktr = readfits('exp_wiener_miceDSV_true_convergence_map.fits')
+    ps1d = readfits('exp_wiener_miceDSV_signal_powspec.fits')
+    
+    # Mass mapping class initialization
+    (nx,ny) = Ncov.shape 
+    M = massmap2d(name='mass')
+    M.init_massmap(nx,ny)
+    M.DEF_niter=200
+    Inpaint=False
+    M.niter_debias=30
+    M.Verbose=False    
+    
+    
+    # Read the noise power spectrum. It has been derived from 
+    # from the covariance matrix using 1000 realization with the command:
+    #    Pn = M.get_noise_powspec(Ncov ,mask=mask,nsimu=1000, inpaint=True)
+    pn = readfits('exp_wiener_miceDSV_noise_powspec.fits')
+
+    # derive the mask from the covariance matrix
+    index = np.where(Ncov<1e2)
+    mask = np.zeros((nx,ny))
+    mask[index] = 1
+    ind = np.where(mask != 1)
+    mask[ind]=0
+    
+    # Shear data class initialization
+    d=shear_data()
+    d.g1=g1
+    d.g2=g2
+    d.Ncov =Ncov
+    d.mask = mask
+    
+    # make Fig. 8 of MCAlens paper
+    tvilut(mask,title='DES-MICE Mask', lut=lut,filename='fig_mice_mask.png', vmin=0, vmax=1)
+    tvilut(smooth2d(ktr, 1.)*mask,title='Convergence map', lut=lut,filename='fig_mice_kappa.png', vmin=-0.03,vmax=0.03)
+    tvilut(g1,title='g1', lut=lut,filename='fig_mice_g1.png', vmin=-0.3,vmax=0.3)
+    tvilut(g2,title='g2', lut=lut,filename='fig_mice_g2.png', vmin=-0.3,vmax=0.3)
+
+
+    # Wiener filtering using the theoretical power spectrum
+    # exemple of wiener routine, without using the iterative prox.
+    # this is not shown in the MCAlens paper
+    kw,wi = M.wiener(g1, g2, ps1d, pn)      
+
+    # Proximal iterative filtering. 
+    ke_pwiener,kb_pwiener = M.prox_wiener_filtering(g1, g2, ps1d, Ncov, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)
+    #  Proximal iterative filtering with Inpainting
+    ke_inp_pwiener,kb_winp = M.prox_wiener_filtering(g1, g2, ps1d, Ncov, Pn=pn, Inpaint=True) #, Pn=Pn) # ,ktr=InShearData.ktr)
+
+    # make Fig. 9 of MCAlens paper
+    tvilut(ke_pwiener,title='Wiener', lut=lut,filename='fig_mice_wiener.png', vmin=-0.004,vmax=0.004)
+    tvilut(ke_inp_pwiener,title='Inpainted Wiener', lut=lut,filename='fig_mice_inp_wiener.png', vmin=-0.004,vmax=0.004)
+
+    # agnostic wiener filtering
+    # estimate a noisy power spectrum 
+    # pen,pke = estimate_pk(d,M,pn)
+    pen = readfits('exp_wiener_miceDSV_estimated_noisy.fits')
+    pke = readfits('exp_wiener_miceDSV_estimated_theoretical_pk.fits')
+    kiwa,iwi = M.prox_wiener_filtering(g1, g2, pke, Ncov, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)
+
+    plt.figure()
+    s=0
+    plt.plot(pen,'blue', label='PowSpec(KappaE) - Pn')
+    plt.plot(pke, color='red', label='Fit')
+    plt.plot(ps1d,color='black', label='True Pk power spectrum') 
+    plt.legend(loc='upper right')
+    plt.savefig('fig_plot_mice_pk.png')
+    plt.show()
+       
+    # Example of error calculation at a give scale
+    sig=2
+    print("== ERROR Sigma = ", sig)
+    ks =  M.gamma_to_cf_kappa(g1,g2) 
+    ks = ks.real
+    Err_ks = get_rms_error(ks, ktr,mask,sigma=sig)      
+    print("   Kaiser Squires Error: ", Err_ks)
+    Err_kiw = get_rms_error(ke_pwiener,ktr,mask,sigma=sig) 
+    print("   Iterative Wiener Error: ", Err_kiw)
+    Err_kiwa = get_rms_error(kiwa,ktr,mask,sigma=sig) 
+    print("   Agnostic Iterative Wiener Error: ", Err_kiwa)
+
+
+def make_fig_exp_ramses(lut=DEF_lut):    
+    D = shear_data()
+    D.Ncov = readfits('exp_wiener_miceDSV_covmat.fits') 
+    newInputSimu = readfits('exp_ramses_true_convergence_map.fits')
+    (nx,ny) = D.Ncov.shape # assume a diagonal cov mat
+    D.nx = nx
+    D.ny = ny
+    M = massmap2d(name='mass')
+    M.init_massmap(D.nx,D.ny)
+    M.DEF_niter=100
+    Bmode=True
+    Inpaint=False
+
+    index = np.where(D.Ncov<1e2)
+    D.mask = np.zeros((nx,ny))
+    D.mask[index] = 1
+    mask=D.mask
+    n1,n2 = D.get_shear_noise()
+    nxin,nyin = newInputSimu.shape
+    depx= (nxin-nx)//2
+    depy= (nyin-ny) //2
+    D.ktr= newInputSimu[depx:depx+nx,depy:depy+ny]
+    
+    Minput = massmap2d(name='mass')
+    Minput.init_massmap(nxin,nyin)  
+    (g1t,g2t) = Minput.kappa_to_gamma(newInputSimu) 
+    D.g1t = g1t[depx:depx+nx,depy:depy+ny]
+    D.g2t = g2t[depx:depx+nx,depy:depy+ny]
+    pk = im_isospec(D.ktr)
+    D.ps1d = pk
+    D.g1 = (D.g1t + n1) * D.mask
+    D.g2 = (D.g2t + n2) * D.mask
+    
+    # Compute the MCAlens solution
+    M.Verbose=False
+    k1r5,k1i,k2r5,k2i = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Inpaint=Inpaint, Bmode=Bmode, InpNiter=20)
+    # info(D.ktr-k1r5)
+    
+    # Propate noise realization to get a rms map
+    run_sim1=0
+    if run_sim1:
+        Nsimu=100
+        TabSim = np.zeros([Nsimu,nx,ny])
+        for i in range(Nsimu):
+            print("SIMU ",i+1)
+            nk1r5,nk1i,nk2r5,nk2i5 = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Bmode=Bmode, PropagateNoise=True)
+            TabSim[i,:,:]=nk1r5
+        rms = TabSim.std(0)
+        writefits('exp_ramses_mcalens_rms.fits',rms)
+    else:
+        rms = readfits("exp_ramses_mcalens_rms.fits")
+    
+    # make Fig.2 of MCAlens paper
+    vm=0.2
+    vmin=-0.1
+    tvilut(D.ktr*mask,title='True kappa map',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_kt.png')
+    tvilut(k1r5*mask, title='MCAlens',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_mcalens_sig5_masked.png')
+    tvilut((k1r5-k2r5)*mask, title='MCAlens-Gaussian Component',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_mcalens_gaussian_sig5_masked.png')
+    tvilut(k2r5*mask, title='MCAlens-Sparse Component',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_ramses_mcalens_sparse_sig5_masked.png')
+
+    # make Fig.3 of MCAlens paper
+    tvilut(rms*mask,title='MCAlens RMS Map',fs=5, lut=lut, filename='fig_ramses_mcalens_rms.png')
+    tvilut(np.abs(k1r5/rms*mask),title='MCAlens SNR Map',fs=5, lut=lut, vmax=10,filename='fig_ramses_mcalens_snr.png')
+    tvilut(M.WT_ActiveCoef.sum(0), title='Active WT Coef Mask',fs=5, lut=lut, filename='fig_ramses_mcalens_sig5_act_coef_support.png')
+
+
+def make_fig_exp_columbia(lut=DEF_lut):        
+    D = shear_data()
+    cov_mice = readfits('exp_wiener_miceDSV_covmat.fits') 
+    newInputSimu = readfits('exp_colombia_true_convergence_map.fits')
+    D.ktr=newInputSimu
+    ResolPixel=0.8  # the orignal image has been rebinned by a factor 2
+    # MICE cov mat = 10 Euclid noise
+    # mice resol = 4.5
+    # Colombia resol = 0.8     
+    # cov_columbia = cov_mice / 10 *  area_mice / area_jia
+    # ==>  4.5**2 / 0.8**2 /10 = 3.16
+    ScaleToEuclidNoise=3.16
+    D.Ncov = cov_mice * ScaleToEuclidNoise
+    (nx,ny) = D.Ncov.shape # assume a diagonal cov mat
+    D.nx = nx
+    D.ny = ny
+    index = np.where(D.Ncov<1e2)
+    D.mask = np.zeros((nx,ny))
+    D.mask[index] = 1
+    mask=D.mask
+    n1,n2 = D.get_shear_noise()
+    FirstRun=False
+    if FirstRun:
+        pn = M.get_noise_powspec(D.Ncov ,mask=D.mask,nsimu=1000, inpaint=True)
+        writefits("exp_colombia_noise_powspec.fits", pn)
+        FirstRun=False
+    else:
+        pn = readfits("exp_colombia_noise_powspec.fits")
+
+    M = massmap2d(name='mass')
+    M.init_massmap(D.nx,D.ny)
+    M.DEF_niter=100
+    Bmode=True
+    Inpaint=False
+    
+    (g1t,g2t) = M.kappa_to_gamma(D.ktr) 
+    D.g1t = g1t 
+    D.g2t = g2t 
+    pk = im_isospec(D.ktr)
+    D.ps1d = pk
+    D.g1 = (D.g1t + n1) * D.mask
+    D.g2 = (D.g2t + n2) * D.mask
+    
+    # Compute the MCAlens solution
+    M.Verbose=False
+    k1r5,k1i,k2r5,k2i = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Inpaint=Inpaint, Bmode=Bmode, InpNiter=20)
+    # info(D.ktr-k1r5)
+    kiw,iwi = M.prox_wiener_filtering(D.g1, D.g2, D.ps1d, D.Ncov, Inpaint=Inpaint, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)
+    ks =  M.g2k(D.g1,D.g2) 
+    Sigma2Fwhm = 2.355
+    sig=2.
+    ks2=smooth2d(ks, 2.) * mask # Resol = ResolPixel * Sigma2Fwhm * sig = 3.8 amin
+
+    # Propate noise realization to get a rms map
+    run_sim1=0
+    if run_sim1:
+        Nsimu=100
+        TabSim = np.zeros([Nsimu,nx,ny])
+        for i in range(Nsimu):
+            print("SIMU ",i+1)
+            nk1r5,nk1i,nk2r5,nk2i5 = M.sparse_wiener_filtering(D, D.ps1d, Nsigma=5, Bmode=Bmode, PropagateNoise=True)
+            TabSim[i,:,:]=nk1r5
+        rms = TabSim.std(0)
+        writefits('exp_columbia_mcalens_rms.fits',rms)
+    else:
+        rms = readfits("exp_columbia_mcalens_rms.fits")
+
+    vm=0.1
+    vmin=-0.1
+    # make Fig.5 of MCAlens paper
+    tvilut(D.ktr*mask,title='True kappa map',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_kt.png')
+    tvilut(kiw*mask, title='Wiener',fs=5, vmin=-0.02, vmax=0.02,lut=lut, filename='fig_jia_wiener.png')
+    tvilut(ks2,title='KS (Fwhm=3.8 arcmin)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_ks2.png')
+
+    tvilut(k1r5*mask, title='MCAlens (lambda=5)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_mcalens_sig5.png')
+    tvilut((k1r5-k2r5)*mask, title='MCAlens-Gaussian Component (lambda=5)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_mcalens_xw_sig5.png')
+    tvilut(k2r5*mask, title='MCAlens-Sparse Component (lambda=5)',fs=5, vmin=vmin, vmax=vm,lut=lut, filename='fig_jia_mcalens_xs_sig5.png')
+
+    tvilut(rms*mask,title='MCAlens RMS Map',fs=5, lut=lut, filename='fig_jia_mcalens_rms.png')
+    tvilut(np.abs(k1r5/rms*mask),title='MCAlens SNR Map',fs=5, lut=lut, filename='fig_jia_mcalens_snr.png')
+    tvilut(M.WT_ActiveCoef.sum(0), title='Active WT Coef Mask', lut=lut,fs=5, filename='fig_jia_mcalens_sig5_act_coef_support.png')
+
+
+# Routine for COSMOS EXPERIMENT
+def get_extend_radec():
+    ra0, dec0 = (150.11, 2.24) # from cosmos.astro.caltech.edu (could also just use the medians of positions)
+    proj = gnom.projector(ra0, dec0)
+    dx = np.deg2rad(1.5) / 2. # 1.5 degrees across
+    dy = dx
+    extent_xy = [-dx, dx, -dy, dy]
+    ra_min, dec_min = proj.xy2radec(-dx, -dy)
+    ra_max, dec_max = proj.xy2radec(dx, dy)
+    extent_radec = [ra_min, ra_max, dec_min, dec_max]
+    return extent_radec
+    
+def tvradec(ima, title='ima',vmin=None,vmax=None,smooth=None,xclus=False,mtext=False,m500min=0, zmin=0.3,zmax=1,ztext=False,lut=DEF_lut,filename=None,extent_radec=None):
+    if extent_radec is None:
+        extent_radec = get_extend_radec()
+
+    fs = 18 # fontsize        
+    fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+    # Kappa map
+    if smooth is None:
+        imaS = ima
+    else:
+        imaS = ndimage.gaussian_filter(ima, smooth)
+    img = ax.imshow(imaS, origin='lower', cmap=lut, vmin=vmin, vmax=vmax, extent=extent_radec)
+    draw_footprint(ax)
+    
+    # Xray clusters
+    if xclus:
+        xclusters = np.loadtxt("xray.txt")
+        highz = (xclusters[:, 6] >= zmin) & (xclusters[:, 6] <= zmax)
+        for cluster in xclusters[highz]:
+            ra_cl, dec_cl, z_cl = cluster[1], cluster[2], cluster[6]
+            m500 = cluster[7]
+            if m500 > m500min:
+                ax.scatter(ra_cl, dec_cl, c='w', s=12)
+                if ztext:
+                    ax.text(ra_cl + 0.03, dec_cl + 0.02, "{:.2f}".format(z_cl), fontsize=8, c='w')
+                if mtext:
+                    ax.text(ra_cl + 0.03, dec_cl - 0.02, "{:.2f}".format(m500), fontsize=8, c='w')
+
+    # Clean up and decorate
+    ax.set_aspect('equal')
+    ax.set_xlim(ax.get_xlim()[::-1])
+    ax.set_title(title, fontsize=fs)
+    ax.set_xlabel("RA [deg]", fontsize=fs)
+    ax.set_ylabel("Dec [deg]", fontsize=fs)
+    fig.colorbar(img, ax=ax)
+    if filename is not None:
+        plt.savefig(filename)
+
+def tvglimpse(mask=None,vmin=0,vmax=0.04,xclus=False, lut=DEF_lut, mtext=False,m500min=0, zmin=0.3,zmax=1,ztext=False,filename=None):
+    hdulist = fits.open('cosmos_bright_lambda3.0_niter1000_debias1000.fits')
+    kappa, ra, dec = [hdu.data for hdu in hdulist]
+    if mask is not None:
+        kappa *= mask
+    
+    fs = 18 # fontsize        
+
+    # Determine glimpse RA/Dec extent (not perfect !)
+    ra_min_gl = np.mean([ra[0][0], ra[-1][0]])
+    ra_max_gl = np.mean([ra[0][-1], ra[-1][-1]])
+    dec_min_gl = np.mean([dec[0][0], dec[0][-1]])
+    dec_max_gl = np.mean([dec[-1][0], dec[-1][-1]])
+    extent_glimpse = [ra_min_gl, ra_max_gl, dec_min_gl, dec_max_gl]
+    # extent_glimpse = [149.04680898212678,151.17319101787328,1.1774193776516106,3.3018101267642783]
+    
+    fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+    img = ax.imshow(kappa, origin='lower', cmap=lut, vmax=0.1, extent=extent_glimpse)
+    draw_footprint(ax)
+
+    # Plot xray clusters
+    if xclus:
+        xclusters = np.loadtxt("xray.txt")
+        highz = (xclusters[:, 6] >= zmin) & (xclusters[:, 6] <= zmax)
+
+        for cluster in xclusters[highz]:
+            ra_cl, dec_cl, z_cl = cluster[1], cluster[2], cluster[6]
+            m500 = cluster[7]
+            if m500 > m500min:
+                ax.scatter(ra_cl, dec_cl, c='w', s=12)
+                if ztext:
+                    ax.text(ra_cl + 0.03, dec_cl + 0.02, "{:.2f}".format(z_cl), fontsize=8, c='w')
+                if mtext:
+                    ax.text(ra_cl + 0.03, dec_cl - 0.02, "{:.2f}".format(m500), fontsize=8, c='w')
+        
+    
+    # Clean up and decorate
+    extent_radec = get_extend_radec()
+    ax.set_aspect('equal')
+    ax.set_title("Glimpse2D ($\lambda=3.0$)", fontsize=fs)
+    ax.set_xlabel("RA [deg]", fontsize=fs)
+    ax.set_ylabel("Dec [deg]", fontsize=fs)
+    # ax.set_xlim(149.25, 151)
+    # ax.set_ylim(1.375, 3.125)
+    ax.set_xlim(extent_radec[:2])
+    ax.set_ylim(extent_radec[2:])
+    ax.set_xlim(ax.get_xlim()[::-1])
+    fig.colorbar(img, ax=ax)
+    if filename is not None:
+        plt.savefig(filename)    
+
+
+
+def make_fig_exp_cosmos(lut=DEF_lut, WriteRes=False):
+    # Using bright galaxy catalog, we got these 2 binned shear images
+    e1map = readfits('cosmos_g1.fits')
+    e2map = readfits('cosmos_g2.fits')
+    galmap = readfits('cosmos_countmap.fits')
+    ps1d = readfits('cosmos_estimated_signal_powspec.fits')
+    pn = readfits('cosmos_estimated_noise_powspec.fits')
+    
+    # Kaiser-Squires inversion
+    # kE, kB = ks93(e1map, e2map)
+
+    D = shear_data()
+    D.g1 = e1map
+    D.g2 = e2map 
+    SigmaNoise=0.28
+    (nx,ny) = e1map.shape # assume a diagonal cov mat
+    ind = np.where(galmap >  0 )
+    D.mask = np.zeros((nx,ny))
+    D.mask[ind] = 1
+    Ncov=np.zeros((nx,ny))
+    Ncov[ind] = 2. * SigmaNoise**2 / galmap[ind]
+    Ncov[Ncov==0] = 1e9
+    D.Ncov = Ncov
+    D.nx = nx
+    D.ny = ny
+
+
+    FNsuf = "_db"
+    M = massmap2d(name='mass')
+    M.init_massmap(D.nx,D.ny)  
+    M.DEF_niter=100
+    Inpaint=False
+    Bmode=True
+    g1=D.g1
+    g2=D.g2
+    ks =  M.g2k(g1,g2) 
+    ks2 = M.smooth(ks, sigma=2)
+    kiw,iwi = M.prox_wiener_filtering(D.g1, D.g2, ps1d, D.Ncov, Inpaint=Inpaint, Pn=pn) #, Pn=Pn) # ,ktr=InShearData.ktr)
+
+    k1r5,k1i5,k2r5,k2i = M.sparse_wiener_filtering(D, ps1d, Nsigma=5, Inpaint=Inpaint, Bmode=Bmode, ktr=None)
+    
+    vmin=-0.03
+    vmax=0.1
+    zmax=0.99
+    m500min=3
+    mtext=False # overplot x-clusters M500
+    ztext=True # overplot x-clusters redshift
+    Sigma2Fwhm = 2.355
+    smooth= 1.2 / Sigma2Fwhm   # resolution in Massey 07 paper
+    xclus=True # True to overplot x-clusters
+    FN5="fig_cosmos"+FNsuf+"_mcalens_5sigma.png"
+    m=D.mask
+    
+    FN="fig_cosmos" + FNsuf + "_" + "galmap" + ".png"
+    tvradec(galmap, 'Galaxy number count',lut=lut,filename=FN)
+    FNW="fig_cosmos"+FNsuf+"_wiener.png"
+    tvradec(kiw*m, title='Wiener',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=-0.01,vmax=0.02,zmax=zmax, smooth=smooth,ztext=ztext,filename=FNW)
+    FN="fig_cosmos"+FNsuf+"_ks2.png"
+    s2=1.2 / Sigma2Fwhm * 2.
+    tvradec(ks2, title='KS (FWHM=2.4arcmin)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=s2,ztext=ztext,filename=FN)
+    FNG="fig_cosmos"+FNsuf+"_glimpse.png"
+    tvglimpse(mask=m, vmin=vmin,vmax=vmax,xclus=xclus,lut=lut, mtext=mtext,m500min=m500min,zmax=zmax,ztext=ztext,filename=FNG)
+    tvradec(k1r5*m, title='MCALens (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN5)
+    # FN5="fig_cosmos"+FNsuf+"_mcalens_5sigma_xs.png"
+    #tvradec(k2r5*m, title='MCALens-Gaussian Component  (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN5)
+    #FN5="fig_cosmos"+FNsuf+"_mcalens_5sigma_xw.png"
+    #tvradec((k1r5-k2r5)*m, title='MCALens-Gaussian Component (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN5)
+    FN="fig_cosmos"+FNsuf+"_mcalens_5sigma_bmode.png"
+    tvradec(k1i5, title='B-mode (lambda=5)',xclus=xclus,lut=lut, mtext=mtext,m500min=m500min, vmin=vmin,vmax=vmax,zmax=zmax, smooth=smooth,ztext=ztext,filename=FN)
+
+        
+def make_fig_exp_sphere(lut=DEF_lut):
+    dpi=100
+    k = mrs_read("exp_sphere_mice_kappa.fits")
+    nside=hp.get_nside(k)
+    print("Nside = ", nside)
+    print("Resol pixel (arcmin)= ", hp.nside2resol(nside, arcmin=True))
+    
+    g1 = mrs_read("exp_sphere_mice_g1_noisy.fits")
+    g2 = mrs_read("exp_sphere_mice_g2_noisy.fits")
+
+    # k0p5 = hp.smoothing(k, sigma=0.5/360. * (np.pi*2),pol=False)
+    k1 = hp.smoothing(k, sigma=1./360. * (np.pi*2),pol=False)
+    # k2 = hp.smoothing(k, sigma=2./360. * (np.pi*2),pol=False)
+    k3 = hp.smoothing(k, sigma=3./360. * (np.pi*2),pol=False)
+
+    hp.mollview(k1,title='Simulated kappa map (1 degree)', cmap=lut)
+    plt.savefig('fig_sphere_mice_input_1deg.png', dpi=dpi)
+    hp.mollview(k3,title='Simulated kappa map (3 degrees)', cmap=lut)
+    plt.savefig('fig_sphere_mice_input_3deg.png', dpi=dpi)
+
+    #hp.mollview(k0p5,title='Simulated kappa map (0.5 degree)', cmap=lut)
+    #plt.savefig('fig_sphere_mice_input_0.5deg.png', dpi=dpi)
+    #hp.mollview(k2,title='Simulated kappa map (2 degrees)', cmap=lut)
+    #plt.savefig('fig_sphere_mice_input_2deg.png', dpi=dpi)    
+    
+    FirstRun=0
+    if FirstRun:
+        cmd="wls_mcalens -F2 -i200 -N exp_sphere_covmat.fits -v -s5 -n5  -m4 -S exp_sphere_mice_kappa_cl.fits exp_sphere_mice_g1_noisy.fits exp_sphere_mice_g2_noisy.fits  res_mice_200"
+        args = shlex.split(cmd)
+        call(args)
+    x1 = mrs_read('res_mice_200_e.fits')
+    xs1 = mrs_read('res_mice_200_sparse_e.fits')
+
+    x11 = hp.smoothing(xs1, sigma=1./360. * (np.pi*2),pol=False)
+    
+    hp.mollview(x11,title='MCALens: sparse component (1 degree)', cmap=lut)
+    plt.savefig('fig_sphere_mice_mcalens_sparse.png', dpi=dpi)
+    
+    hp.mollview(x1-xs1,title='MCALens: Wiener component', cmap=lut)
+    plt.savefig('fig_sphere_mice_mcalens_wiener.png', dpi=dpi)
+
+
+
+def make_all_figs(lut='magma'):
+    make_fig_exp_wiener(lut=lut)
+    make_fig_exp_columbia(lut=lut)
+    make_fig_exp_ramses(lut=lut)
+    make_fig_exp_cosmos(lut=lut)
+    make_fig_exp_sphere(lut=lut)
+
+
+lut=DEF_lut
+make_all_figs(lut=lut)
+
+

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -752,8 +752,14 @@ class massmap2d:
 
     def mult_wiener(self, map, WienerFilterMap):
         """ " apply one wiener step in the iterative wiener filtering"""
+        # TODO: Modify `get_ima_spectrum_map` in order to avoid `np.fft.fftshift`
+        # (should fix the bug with odd-sized arrays)
         return np.fft.ifft2(
-            np.fft.fftshift(WienerFilterMap * np.fft.fftshift(np.fft.fft2(map)))
+            np.fft.fftshift(
+                WienerFilterMap * np.fft.fftshift(
+                    np.fft.fft2(map), axes=(-2, -1)
+                ), axes=(-2, -1)
+            )
         )
 
     def wiener(self, gamma1, gamma2, PowSpecSignal, PowSpecNoise):

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -39,20 +39,17 @@ def get_ima_spectrum_map(Px, nx, ny):
         2D image.
     """
     Np = Px.shape[0]
-    #    print("nx = ", nx, ", ny = ", ny, ", np = ", Np)
-    k_map = np.zeros((nx, ny))
-    power_map = np.zeros((nx, ny))
-    #    info(k_map)
-    for (i, j), val in np.ndenumerate(power_map):
-        k1 = i - nx / 2.0
-        k2 = j - ny / 2.0
-        k_map[i, j] = np.sqrt(k1 * k1 + k2 * k2)
-        if k_map[i, j] == 0:
-            power_map[i, j] = 0.0
-        else:
-            ip = int(k_map[i, j])
-            if ip < Np:
-                power_map[i, j] = Px[ip]
+    Px[0] = 0. # set the zero frequency to zero
+    Px = np.append(Px, 0) # set to 0 all frequencies above Np
+    k1, k2 = np.meshgrid(
+        np.arange(nx) - nx / 2.0,
+        np.arange(ny) - ny / 2.0,
+        indexing='ij'
+    )
+    ip = np.sqrt(k1**2 + k2**2).astype(int) # map of frequency norms
+    ip[ip > Np] = Np
+    power_map = Px[ip] # 2D power spectrum (isotropic)
+
     return power_map
 
 

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -981,12 +981,16 @@ class massmap2d:
         nx, ny = gamma1.shape[-2:]
         if self.Verbose:
             print(f"{msg}: ", nx, ny, ", Niter = ", niter)
+
+        if not isinstance(InshearData.mask, np.ndarray):
+            mask = (InshearData.Ncov != 0).astype(int) # shape = (nx, ny)
+        else:
+            mask = InshearData.mask
+        InshearData.Ncov[InshearData.Ncov == 0] = 1e9  # infinite value for no measurement
         Ncv = InshearData.Ncov / 2.0 # shape = (nx, ny)
-        mask = (Ncv != 0).astype(int) # shape = (nx, ny)
-        Ncv[Ncv == 0] = 1e9  # infinite value for no measurement
 
         # find the minimum noise variance
-        ind = np.where(Ncv != 0)
+        ind = np.where(Ncv != 0) # TODO: useless if we have set Ncv[mask == 0] = 1e9 before
         tau = np.min(Ncv[ind])
 
         # set the step size
@@ -994,7 +998,7 @@ class massmap2d:
         eta = tau
         # compute signal coefficient
         Esn = eta / Ncv # shape = (nx, ny)
-        Esn[Esn == np.inf] = 0
+        Esn[Esn == np.inf] = 0 # TODO: useless if we have set Ncv[mask == 0] = 1e9 before
 
         return gamma1, gamma2, nx, ny, eta, Esn, mask, ind, tau, niter
     

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -1051,10 +1051,8 @@ class massmap2d:
 
     def prox_wiener_filtering(
         self,
-        gamma1,
-        gamma2,
+        InshearData,
         PowSpecSignal,
-        NcvIn,
         Pn=None,
         niter=None,
         Inpaint=False,
@@ -1068,12 +1066,10 @@ class massmap2d:
             "CMB map restoration", Advances in Astronomy , 2012, Id703217, 2012.
         Parameters
         ----------
-        gamma1,  gamma2: 2D np.ndarray
-            shear fied.
+        InshearData : Shear Class
+            Class contains the shear information.
         PowSpecSignal : 1D np.ndarray
             Signal theorical power spectrum.
-        Ncv : 2D np.ndarray
-            Diagonal covariance matrix (same size as gamma1 and gamm2), i.e. variance per pixel
         Pn: 1D np.ndarray, optional
             noise theorical power spectrum.
         niter: int
@@ -1095,7 +1091,7 @@ class massmap2d:
         (nx, ny) = gamma1.shape
         if self.Verbose:
             print("Iterative Wiener filtering: ", nx, ny, ", Niter = ", niter)
-        Ncv = NcvIn / 2.0
+        Ncv = InshearData.Ncov / 2.0
         Ncv[Ncv == 0] = 1e9  # infinite value for no measurement
         index = np.where(Ncv < 1e2)
         mask = np.zeros((nx, ny))
@@ -1140,7 +1136,7 @@ class massmap2d:
         # print("lmax = ", lmax)
 
         if PropagateNoise is not None:
-            n1, n2 = PropagateNoise.get_shear_noise()
+            n1, n2 = InshearData.get_shear_noise()
             n1 = n1 * mask
             n2 = n2 * mask
             gamma1 = n1
@@ -1180,9 +1176,7 @@ class massmap2d:
 
     def prox_mse(
         self,
-        gamma1,
-        gamma2,
-        NcvIn,
+        InshearData,
         niter=None,
         Inpaint=True,
         sigma=None,
@@ -1195,10 +1189,8 @@ class massmap2d:
 
         Parameters
         ----------
-        gamma1,  gamma2: 2D np.ndarray
-            shear fied.
-        Ncv : 2D np.ndarray
-            Diagonal covariance matrix (same size as gamma1 and gamm2), i.e. variance per pixel
+        InshearData : Shear Class
+            Class contains the shear information.
         niter: int
             number of iterations. Default is DEF_niter
         Inpaint: bool, optional
@@ -1221,7 +1213,7 @@ class massmap2d:
         (nx, ny) = gamma1.shape
         if self.Verbose:
             print("Proxinal MSE estimator: ", nx, ny, ", Niter = ", niter)
-        Ncv = NcvIn / 2.0
+        Ncv = InshearData.Ncov / 2.0
         Ncv[Ncv == 0] = 1e9  # infinite value for no measurement
         index = np.where(Ncv < 1e2)
         mask = np.zeros((nx, ny))
@@ -1241,7 +1233,7 @@ class massmap2d:
         Esn[Esn == np.inf] = 0
 
         if PropagateNoise is not None:
-            n1, n2 = PropagateNoise.get_shear_noise()
+            n1, n2 = InshearData.get_shear_noise()
             n1 = n1 * mask
             n2 = n2 * mask
             gamma1 = n1

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -111,19 +111,9 @@ class shear_data:
             MaxCov = np.max(Mat[ind])
             ind = np.where(self.mask == 0)
             Mat[ind] = MaxCov
-            # info(Mat, name="cov")
-            # info(Mat*self.mask, name="cov")
-            # print("MaxCov = ", MaxCov)
-            # tvima(self.mask)
         n1 = np.random.normal(loc=0.0, scale=Mat)
         n2 = np.random.normal(loc=0.0, scale=Mat)
         return n1, n2
-
-
-# class shear_simu():
-#     def __init__(self):
-#         a=0
-#     a = np.random.normal(loc=0.0, scale=10.0, size=[200])
 
 
 def massmap_get_rms_error(Res, TrueSol, Mask, sigma=0):
@@ -398,12 +388,7 @@ class massmap2d:
             pke[fp::] = pke[fp]
             pke[fp::] = min_end
 
-        # pke[pkb < 0] = 0
         pkb[pkb < 0] = 0
-        # pe = pe - pn/fsky
-        # pb = pb - pn/fsky
-        # pef=mr_prog(pe, prog="mr1d_filter -m5 -P ")
-        # pbf=mr_prog(pb, prog="mr1d_filter -m5 -P ")
         tv = 0
         if tv:
             plot(pke)
@@ -731,41 +716,29 @@ class massmap2d:
             Nrea = self.DEF_Nrea
         if FirstDetectScale is None:
             FirstDetectScale = DEF_FirstDetectScale
-        # TabFDRNSigma = [5,,4.5,3.5,3.]
-        # TabFDRNSigma = [5.,4.,3.,2.5,2.]
         for j in range(Last):
             wtscale = self.WT.get_scale(j)
-            # if j == 2:
-            #    tvilut(wtscale,title='scale2')
-            # Nsigma = TabFDRNSigma[j]
             if j == 0:
                 Nsig = Nsigma + 1
             else:
                 Nsig = Nsigma
-            # vThres = WT_Sigma * Nsigma * self.WT.TabNorm[j]
             if OnlyPos is False:
                 if UseRea:
                     wsigma = WT_Sigma[j, :, :]
                     ind = np.where(np.abs(wtscale) > wsigma * Nsig * self.WT.TabNorm[j])
-                    # WT_Support[j,:,:] = np.where( np.abs(self.WT.coef[j,:,:]) > WT_Sigma[j,:,:] * Nsig * self.WT.TabNorm[j], 1, 0)
                 else:
                     ind = np.where(
                         np.abs(wtscale) > SigmaNoise * Nsig * self.WT.TabNorm[j]
                     )
-                    # WT_Support[j,:,:] = np.where( np.abs(self.WT.coef[j,:,:]) > SigmaNoise * Nsig * self.WT.TabNorm[j], 1, 0)
             else:
                 if UseRea:
                     wsigma = WT_Sigma[j, :, :]
-                    # WT_Support[j,:,:] = np.where( self.WT.coef[j,:,:] > WT_Sigma[j,:,:] * Nsig * self.WT.TabNorm[j], 1, 0)
                     ind = np.where(wtscale > wsigma * Nsig * self.WT.TabNorm[j])
                 else:
                     T = SigmaNoise * Nsig * self.WT.TabNorm[j]
                     ind = np.where(wtscale > T)
-                    # WT_Support[j,:,:] = np.where( self.WT.coef[j,:,:] > SigmaNoise * Nsig * self.WT.TabNorm[j], 1, 0)
             wtscale[:, :] = 0
             wtscale[ind] = 1
-            # if j == 2:
-            #    tvilut(wtscale,title='sup2')
             WT_Support[j, :, :] = wtscale
         if FirstDetectScale > 0:
             WT_Support[0:FirstDetectScale, :, :] = 0
@@ -841,13 +814,6 @@ class massmap2d:
 
         if self.Verbose:
             print("Wiener filtering: ", nx, ny)
-        # if mask is None:
-        #    print("Wiener NO MASK")
-        # info(gamma1, name="Wiener g1: ")
-        # info(gamma2, name="Wiener g2: ")
-        # info(PowSpecSignal, name="Wiener PowSpecSignal: ")
-        # info(Ncv, name="Wiener Ncv: ")
-        # if isinstance(PowSpecNoise, int):
 
         Ps_map = get_ima_spectrum_map(PowSpecSignal, nx, ny)
         Pn_map = get_ima_spectrum_map(PowSpecNoise, nx, ny)
@@ -862,12 +828,10 @@ class massmap2d:
         retr[:, :] = kw.real
         reti[:, :] = kw.imag
 
-        # info(kw.real, name="WIENER OUTPUT: ")
         return retr, reti
 
     def get_lmax_dct_inpaint(self, gamma1, gamma2):
         """return the maximum of the DCT absolute value of the convergence map"""
-        # image, icf = self.H_adjoint_g2eb(gamma1, gamma2)
         eb = self.gamma_to_cf_kappa(gamma1, gamma2)
         lmax = np.max(np.abs(dct2d(eb.real, norm="ortho")))
         return lmax
@@ -1046,7 +1010,6 @@ class massmap2d:
             xi = self.iks(r1, r2, mask, niter=niter, dctmax=dctmax)
             r1[:, :] = xi.real
             r2[:, :] = xi.imag
-        # resi = (gamma1 + 1j * gamma2 -  self.gamma_to_cf_kappa(gamma1,gamma2)) * ResiWeight
         return r1, r2
 
     def prox_wiener_filtering(
@@ -1112,7 +1075,6 @@ class massmap2d:
 
         # calculate the wiener filter coefficients
         Px_map = get_ima_spectrum_map(PowSpecSignal, nx, ny)
-        # info((Px_map + eta))
         Wfc = np.zeros((nx, ny))
         if Pn is not None:
             Pn_map = get_ima_spectrum_map(Pn, nx, ny)
@@ -1122,18 +1084,9 @@ class massmap2d:
             Wfc = Px_map / Den
         else:
             Wfc = Px_map / (Px_map + eta)
-        # info(Esn,name='Esn')
-        # info(mask,name='mask')
-
-        #    writefits("xx_fft_wfc.fits", Wfc)
-        #    t = gamma1 + 1j*gamma2
-        #    z = np.fft.fftshift(np.fft.fft2(t))
-        #    z1 = z*conj(z)
-        #    writefits("xx_fft_k.fits", real(z1))
         if Inpaint:
             lmin = 0
             lmax = self.get_lmax_dct_inpaint(gamma1, gamma2)
-        # print("lmax = ", lmax)
 
         if PropagateNoise is not None:
             n1, n2 = InshearData.get_shear_noise()
@@ -1145,15 +1098,11 @@ class massmap2d:
         for n in range(niter):
             xn = np.copy(xg)
             t1, t2 = self.get_resi(xg, gamma1, gamma2, Esn)
-            # print("T1     Sigma = ", np.std(t1), ", Max = ", np.max(t1))
 
             t = xg + (t1 + 1j * t2)  # xg + H^T(eta / Sn * (y- H * xg))
             xg = self.mult_wiener(t, Wfc)  # wiener filtering in fourier space
             if Inpaint:
                 xg = self.step_dct_inpaint(xg, xn, mask, n, niter, lmin, lmax)
-
-                # print("     Sigma = ", np.std(xg), ", Max = ", np.max(xg))
-            # info(xg.real,name="XGR=>")
 
             if self.Verbose:
                 if ktr is not None:
@@ -1166,9 +1115,6 @@ class massmap2d:
                         ", std ke =  %5.4f" % (np.std(xg[ind] / tau)),
                     )
 
-        #       xg.real = M.inpaint(xg.real, mask, 50)
-        #          if ktr is not None:
-        #              print("Iter ", n+1, ", Err = ", LA.norm(xg.real - ktr) / LA.norm(ktr) * 100.)
         return xg.real, xg.imag
 
     def test(self):
@@ -1256,12 +1202,8 @@ class massmap2d:
         for n in range(niter):
             xn = np.copy(xg)
             t1, t2 = self.get_resi(xg, gamma1, gamma2, Esn)
-            # print("T1     Sigma = ", np.std(t1), ", Max = ", np.max(t1))
 
             xg = xg + (t1 + 1j * t2)  # xg + H^T(eta / Sn * (y- H * xg))
-
-            # print("     Sigma = ", np.std(xg), ", Max = ", np.max(xg))
-            # info(xg.real,name="XGR=>")
 
             if sigma is not None:
                 ksg = ndimage.gaussian_filter(xg.real, sigma=sigma)
@@ -1281,10 +1223,6 @@ class massmap2d:
                         n + 1,
                         ", std ke =  %5.4f" % (np.std(xg[ind] / tau)),
                     )
-
-        #       xg.real = M.inpaint(xg.real, mask, 50)
-        #          if ktr is not None:
-        #              print("Iter ", n+1, ", Err = ", LA.norm(xg.real - ktr) / LA.norm(ktr) * 100.)
 
         return xg.real, xg.imag
 
@@ -1345,9 +1283,6 @@ class massmap2d:
         2D np.ndarray
               B reconstructed mode  of the sparse component.
         """
-
-        # print("Mass Mapping routine")
-
         gamma1 = InshearData.g1
         gamma2 = InshearData.g2
         nx = self.nx
@@ -1384,17 +1319,6 @@ class massmap2d:
         Px_map = get_ima_spectrum_map(PowSpecSignal, nx, ny)
         Wfc = Px_map / (Px_map + eta)
         Wfc[Wfc == np.inf] = 0
-
-        #    writefits("xx_fft_wfc.fits", Wfc)
-        #    t = gamma1 + 1j*gamma2
-        #    z = np.fft.fftshift(np.fft.fft2(t))
-        #    z1 = z*conj(z)
-        #    writefits("xx_fft_k.fits", real(z1))
-
-        ind_maskOK = np.where(mask == 1)
-        ind_maskZero = np.where(mask == 0)
-
-        # xg1,xg2 = self.prox_wiener_filtering(gamma1, gamma2, PowSpecSignal, InshearData.Ncov, Pn=None, niter=10, Inpaint=True, ktr=None)
 
         # Detection of the significant wavelet coefficents.
         # to avoid border artefacts, we first make a rough very smooth estimate
@@ -1435,26 +1359,15 @@ class massmap2d:
         for n in range(niter):
             resi1, resi2 = self.get_resi(
                 xg, gamma1, gamma2, Esn_Sparse
-            )  # , mask=mask, niter=20)
+            )
 
             # sparse component
             xt[:, :] = resi1 + 1j * resi2  # xg + H^T(eta / Sn * (y- H * xg))
             self.WT.transform(xt.real)
             self.WT.coef *= self.WT_ActiveCoef
-            # self.WT.threshold(SigmaNoise=SigmaNoise, Nsigma=Nsigma, ThresCoarse=True, hard=True, FirstDetectScale=FirstDetectScale,Verbose=False)
-            # if OnlyPos:
-            #    ind = np.where(self.WT.coef < 0)
-            #    self.WT.coef[ind]=0
             signif_resi = self.WT.recons()
-            # if n % 10 == 0:
-            #    info(signif_resi)
             rec[:, :] = xs.real + signif_resi
 
-            # if n % 10 == 0:
-            #    print(n, "max = ", np.max(rec))
-
-            # if n % 100 == 0:
-            #    tvilut(rec,title='S_f'+str(n))
             if PropagateNoise is False:
                 if OnlyPos:
                     ind = np.where(rec < 0)
@@ -1475,11 +1388,6 @@ class massmap2d:
             xs = rec + 1j * reci
             xg[:, :] = xw + xs
 
-            # ind_maskOK
-            # xw[:,:] = inp_x[:,:]
-            # Wiener component
-            # calculate the residual
-            # xs =0
             xn = np.copy(xw)
 
             InpMethod1 = 1
@@ -1532,7 +1440,6 @@ class massmap2d:
                         ", Resi ke =  %5.4f" % (np.std(resi1[ind] / tau)),
                         ", Resi kb = %5.4f" % (np.std(resi2[ind]) / tau),
                     )
-        # endfor
 
         return xg.real, xg.imag, xs.real, xs.imag
 
@@ -1626,11 +1533,6 @@ class massmap2d:
                 self.WT_Sigma = self.get_wt_noise_level(InshearData, Nrea=Nrea)
             else:
                 self.WT_Sigma = WT_Sigma
-            #            info(self.WT_Sigma, name='WT_Sigma2')
-            #            if WT_Support is None:
-            #                self.WT_ActiveCoef = self.get_active_wt_coef(InshearData,  UseRea=True, SigmaNoise=1., Nsigma=Nsigma, Nrea=Nrea, WT_Sigma=WT_Sigma)
-            #            else:
-            #                self.WT_ActiveCoef = WT_Support
             WeightResi = InshearData.mask
         else:
             RMS_ShearMap = np.sqrt(InshearData.Ncov / 2.0)
@@ -1677,8 +1579,6 @@ class massmap2d:
                     "Hard = ",
                     hard,
                 )
-        #           for j in range(self.WT.ns):
-        #               print("   Scale ", j+1, ": Numner of active coeffs = ", (self.WT_ActiveCoef[j,:,:]).sum(), ", Nbr (%) = ", (self.WT_ActiveCoef[j,:,:]).sum() / (nx*ny)*100.)
 
         # Initialisation for  inpainting
         WT_Inpaint = 0
@@ -1698,7 +1598,6 @@ class massmap2d:
 
         # Main iteration
         Verbose = self.Verbose
-        # info(WeightResi, name='Esn')
         rec = np.zeros((nx, ny))
         reci = np.zeros((nx, ny))
         for n in range(niter):
@@ -1706,7 +1605,6 @@ class massmap2d:
             # print("XG=", xg.shape)
             resi1, resi2 = self.get_resi(xg, gamma1, gamma2, WeightResi)
             xg += resi1 + 1j * resi2
-            # print("   BEF  0.87?Sparse rec Iter: ", n+1, ", Sol =  %5.4f" %  LA.norm(xg.real))
 
             self.WT.transform(xg.real)
             self.WT.threshold(
@@ -1834,11 +1732,9 @@ class massmap2d:
 
         # find the minimum noise variance
         tau = np.min(RMS_ShearMap)
-        # tau =1.
         SigmaNoise = tau
         # compute signal coefficient
         Esn = tau / RMS_ShearMap
-        # print("size ESN ", vsize(Esn))
 
         if self.Verbose:
             print(
@@ -1979,11 +1875,6 @@ class massmap2d:
         Px_map = get_ima_spectrum_map(PowSpecSignal, nx, ny)
 
         Wfc = Px_map / (Px_map + eta)
-        #    writefits("xx_fft_wfc.fits", Wfc)
-        #    t = gamma1 + 1j*gamma2
-        #    z = np.fft.fftshift(np.fft.fft2(t))
-        #    z1 = z*conj(z)
-        #    writefits("xx_fft_k.fits", real(z1))
         if Inpaint:
             lmin = 0
             lmax = self.get_lmax_dct_inpaint(gamma1, gamma2)
@@ -2017,7 +1908,6 @@ class massmap2d:
             if Inpaint:
                 xg = self.step_dct_inpaint(xg, xn, mask, n, niter, lmin, lmax)
 
-                # xg.real = (1.-mask)*rec + mask * xg.real
             if self.Verbose:
                 ind = np.where(mask == 1)
                 if ktr is not None:
@@ -2039,16 +1929,10 @@ class massmap2d:
                         ", Resi kb = %5.4f" % (np.std(resi2[ind]) / tau),
                     )
 
-        # k = M.inpaint(Res.ikw, d.mask, 50)
-        #          if ktr is not None:
-        #              print("Iter ", n+1, ", Err = ", LA.norm(xg.real - ktr) / LA.norm(ktr) * 100.)
         return xg.real, xs.real
 
 
 ############ END CLASS #######################
-
-# if __name__ == '__main__':
-#     print ( "Main :)")
 
 
 # from lenspack.utils

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -508,7 +508,7 @@ class massmap2d:
             Smoother array.
 
         """
-        return ndimage.filters.gaussian_filter(map, sigma=sigma)
+        return ndimage.gaussian_filter(map, sigma=sigma, axes=(-2, -1))
 
     def kaiser_squires(self, gam1, gam2, sigma=2.0):
         """
@@ -530,7 +530,7 @@ class massmap2d:
         -----
         """
         ks = self.gamma_to_cf_kappa(gam1, gam2)
-        ksg = ndimage.filters.gaussian_filter(ks.real, sigma=sigma)
+        ksg = ndimage.gaussian_filter(ks.real, sigma=sigma, axes=(-2, -1))
         return ksg
 
     # Fast interactive call to kaiser_squires
@@ -556,8 +556,8 @@ class massmap2d:
         -----
         """
         ks = self.gamma_to_cf_kappa(gam1, gam2)
-        ksg = ndimage.filters.gaussian_filter(ks.real, sigma=sigma)
-        ksbg = ndimage.filters.gaussian_filter(ks.imag, sigma=sigma)
+        ksg = ndimage.gaussian_filter(ks.real, sigma=sigma, axes=(-2, -1))
+        ksbg = ndimage.gaussian_filter(ks.imag, sigma=sigma, axes=(-2, -1))
         return ksg, ksbg
 
     def H_operator_eb2g(self, ka_map, kb_map):
@@ -1264,8 +1264,8 @@ class massmap2d:
             # info(xg.real,name="XGR=>")
 
             if sigma is not None:
-                ksg = ndimage.filters.gaussian_filter(xg.real, sigma=sigma)
-                ksbg = ndimage.filters.gaussian_filter(xg.imag, sigma=sigma)
+                ksg = ndimage.gaussian_filter(xg.real, sigma=sigma)
+                ksbg = ndimage.gaussian_filter(xg.imag, sigma=sigma)
                 xg = ksg + 1j * ksbg
 
             if Inpaint:

--- a/pycs/astro/wl/mass_mapping.py
+++ b/pycs/astro/wl/mass_mapping.py
@@ -700,7 +700,7 @@ class massmap2d:
         WT_Support = (
             inp > wsigma * Nsig[:, np.newaxis, np.newaxis] * \
             self.WT.TabNorm[:, np.newaxis, np.newaxis]
-        ).astype(int) # shape = (ns, nx, ny) or (nimgs, ns, nx, ny)
+        ).astype(int) # shape = ([nimgs], ns, nx, ny)
 
         if FirstDetectScale is not None:
             WT_Support[..., :FirstDetectScale, :, :] = 0

--- a/pycs/misc/cosmostat_init.py
+++ b/pycs/misc/cosmostat_init.py
@@ -112,6 +112,10 @@ def hthres(alpha, Thres):
 
 
 def hard_thresholding(alpha, Thres):
+    # alpha: shape = ([nimgs], [Nrea], ns, nx, ny)
+    # Thres: shape = (ns, [nx, ny])
+    if Thres.ndim == 1:
+        Thres = Thres[..., np.newaxis, np.newaxis]
     alpha[np.abs(alpha) <= Thres] = 0
 
 
@@ -119,9 +123,13 @@ def hard_thresholding(alpha, Thres):
 
 
 def soft_thresholding(alpha, Thres):
-    Res = np.copy(np.abs(alpha)) - Thres
+    # alpha: shape = ([nimgs], [Nrea], ns, nx, ny)
+    # Thres: shape = (ns, [nx, ny])
+    if Thres.ndim == 1:
+        Thres = Thres[..., np.newaxis, np.newaxis]
+    Res = np.abs(alpha) - Thres
     Res[Res < 0] = 0
-    alpha[:, :] = np.sign(alpha) * Res[:, :]
+    alpha[:, :] = np.sign(alpha) * Res
 
 
 def sthres(alpha, Thres):

--- a/pycs/misc/cosmostat_init.py
+++ b/pycs/misc/cosmostat_init.py
@@ -45,7 +45,7 @@ from scipy import signal
 
 
 def smooth2d(map, sigma):
-    return ndimage.filters.gaussian_filter(map, sigma=sigma)
+    return ndimage.gaussian_filter(map, sigma=sigma)
 
 
 def rebin2d(a, shape):

--- a/pycs/misc/cosmostat_init.py
+++ b/pycs/misc/cosmostat_init.py
@@ -272,11 +272,15 @@ def writefits(FileName, Data):
 
 
 def dft2d(ima):
-    return np.fft.fftshift(np.fft.fft2(ima))
+    return np.fft.fftshift(
+        np.fft.fft2(ima), axes=(-2, -1)
+    )
 
 
 def idft2d(ima):
-    return np.fft.ifft2(np.fft.ifftshift((ima)))
+    return np.fft.ifft2(np.fft.ifftshift(
+        ima, axes=(-2, -1)
+    ))
 
 
 def idft2dr(ima):
@@ -295,7 +299,9 @@ def conv(ima1, ima2):
 
 
 def dft2dnorm(ima):
-    z = np.fft.fftshift(np.fft.fft2(ima))
+    z = np.fft.fftshift(
+        np.fft.fft2(ima), axes=(-2, -1)
+    )
     z = z * z.conj()
     return z.real
 

--- a/pycs/misc/cosmostat_init.py
+++ b/pycs/misc/cosmostat_init.py
@@ -228,9 +228,7 @@ def vsize(Data):
         dim = d.ndim
         vs = np.zeros([dim + 1], dtype=np.int64)
         vs[0] = dim
-        size = np.array(d.shape)
-        for i in np.arange(dim):
-            vs[i + 1] = size[i]
+        vs[1:] = np.array(d.shape)
     return vs
 
 

--- a/pycs/misc/stats.py
+++ b/pycs/misc/stats.py
@@ -407,7 +407,7 @@ def get_grf(size, intput_power_map=None):
             map_fourier[i, j] = power_sample[i, j]  #
             map_fourier[size - i, size - j] = np.conj(power_sample[i, j])
 
-    map_pixel = np.fft.ifft2(np.fft.fftshift(map_fourier))
+    map_pixel = np.fft.ifft2(np.fft.fftshift(map_fourier, axes=(-2, -1)))
 
     return map_pixel
 

--- a/pycs/misc/stats.py
+++ b/pycs/misc/stats.py
@@ -366,6 +366,10 @@ def get_grf(size, intput_power_map=None):
     np array
         2D images.
     """
+    # TODO: remove for loops for this code
+    # TODO: check this code; it seems like
+    #       `map_fourier[size - i, size - j] = np.conj(power_sample[i, j])`
+    # is overwriting the line just above.
     k_map = np.zeros((size, size), dtype=float)
     power_map = np.zeros((size, size), dtype=float)
     for (i, j), val in np.ndenumerate(power_map):

--- a/pycs/misc/stats.py
+++ b/pycs/misc/stats.py
@@ -410,3 +410,54 @@ def get_grf(size, intput_power_map=None):
     map_pixel = np.fft.ifft2(np.fft.fftshift(map_fourier))
 
     return map_pixel
+
+
+def mad(input_data, axis=None, keepdims=False):
+    r"""Median absolute deviation.
+
+    This method calculates the median absolute deviation of the input data.
+    Modification from modopt.math.stats
+
+    Parameters
+    ----------
+    input_data : numpy.ndarray
+        Input data array
+    axis (int or tuple of ints)
+        Axis or axes along which the mad is computed.
+        The default is to compute the mad of the flattened array.
+    keepdims (bool, optional)
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the original arr.
+
+    Returns
+    -------
+    float
+        MAD value
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from modopt.math.stats import mad
+    >>> a = np.arange(9).reshape(3, 3)
+    >>> mad(a)
+    2.0
+
+    Notes
+    -----
+    The MAD is calculated as follows:
+
+    .. math::
+
+        \mathrm{MAD} = \mathrm{median}\left(|X_i - \mathrm{median}(X)|\right)
+
+    See Also
+    --------
+    numpy.median : median function used
+
+    """
+    return np.median(
+        np.abs(
+            input_data - np.median(input_data, axis=axis, keepdims=True)
+        ), axis=axis, keepdims=keepdims
+    )

--- a/pycs/misc/utilHSS.py
+++ b/pycs/misc/utilHSS.py
@@ -8,130 +8,68 @@ import scipy.fftpack as pfft
 
 
 def fftshift2d1d(cubefft):
-    (nz, nx, ny) = np.shape(cubefft)
-    cubefftSh = (
-        np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-    )  # Convert to complex array
-    for fm in np.arange(nz):
-        cubefftSh[fm] = pfft.fftshift(cubefft[fm])
-    return cubefftSh
+    return np.fft.fftshift(cubefft, axes=(1, 2))
 
 
 def ifftshift2d1d(cubefftSh):
-    (nz, nx, ny) = np.shape(cubefftSh)
-    cubefft = (
-        np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-    )  # Convert to complex array
-    for fm in np.arange(nz):
-        cubefft[fm] = pfft.ifftshift(cubefftSh[fm])
-    return cubefft
+    return np.fft.ifftshift(cubefftSh, axes=(1, 2))
 
 
 def fft2d1d(cube):
-    (nz, nx, ny) = np.shape(cube)
-    cubefft = (
-        np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-    )  # Convert to complex array
-    for fm in np.arange(nz):
-        cubefft[fm] = pfft.fft2(cube[fm])
-    return cubefft
+    return np.fft.fft2(cube)
 
 
 def ifft2d1d(cubefft):
-    (nz, nx, ny) = np.shape(cubefft)
-    cube = (
-        np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-    )  # Convert to complex array
-    for fm in np.arange(nz):
-        cube[fm] = pfft.ifft2(cubefft[fm])
-    return cube
+    return np.fft.ifft2(cubefft)
 
 
 def fftshiftNd1d(imagefft, N):
+    assert len(imagefft.shape) == (N + 1)
     if N == 1:
-        (nz, ny) = np.shape(imagefft)
-        imagefftSh = (
-            np.zeros((nz, ny)) + np.zeros((nz, ny)) * 1j
-        )  # Convert to complex array
+        axes = 1
     if N == 2:
-        (nz, nx, ny) = np.shape(imagefft)
-        imagefftSh = (
-            np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-        )  # Convert to complex array
-    for fm in np.arange(nz):
-        imagefftSh[fm] = pfft.fftshift(imagefft[fm])
-    return imagefftSh
+        axes = (1, 2)
+    return np.fft.fftshift(imagefft, axes=axes)
 
 
 def ifftshiftNd1d(imagefftSh, N):
+    assert len(imagefftSh.shape) == (N + 1)
     if N == 1:
-        (nz, ny) = np.shape(imagefftSh)
-        imagefft = (
-            np.zeros((nz, ny)) + np.zeros((nz, ny)) * 1j
-        )  # Convert to complex array
+        axes = 1
     if N == 2:
-        (nz, nx, ny) = np.shape(imagefftSh)
-        imagefft = (
-            np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-        )  # Convert to complex array
-    for fm in np.arange(nz):
-        imagefft[fm] = pfft.ifftshift(imagefftSh[fm])
-    return imagefft
+        axes = (1, 2)
+    return np.fft.ifftshift(imagefftSh, axes=axes)
 
 
 def fftNd1d(image, N):
+    assert len(image.shape) == (N + 1)
     if N == 1:
-        (nz, ny) = np.shape(image)
-        imagefft = (
-            np.zeros((nz, ny)) + np.zeros((nz, ny)) * 1j
-        )  # Convert to complex array
+        out = np.fft.fft(image)
     if N == 2:
-        (nz, nx, ny) = np.shape(image)
-        imagefft = (
-            np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-        )  # Convert to complex array
-    for fm in np.arange(nz):
-        if N == 1:
-            imagefft[fm] = pfft.fft(image[fm])
-        if N == 2:
-            imagefft[fm] = pfft.fft2(image[fm])
-    return imagefft
+        out = np.fft.fft2(image)
+    return out
 
 
 def ifftNd1d(imagefft, N):
+    assert len(imagefft.shape) == (N + 1)
     if N == 1:
-        (nz, ny) = np.shape(imagefft)
-        image = np.zeros((nz, ny)) + np.zeros((nz, ny)) * 1j  # Convert to complex array
+        out = np.fft.ifft(imagefft)
     if N == 2:
-        (nz, nx, ny) = np.shape(imagefft)
-        image = (
-            np.zeros((nz, nx, ny)) + np.zeros((nz, nx, ny)) * 1j
-        )  # Convert to complex array
-    for fm in np.arange(nz):
-        if N == 1:
-            image[fm] = pfft.ifft(imagefft[fm])
-        if N == 2:
-            image[fm] = pfft.ifft2(imagefft[fm])
-    return image
+        out = np.fft.ifft2(imagefft)
+    return out
 
 
 def mad(alpha):
     dim = np.size(np.shape(alpha))
     if dim == 1:
         alpha = alpha[np.newaxis, :]
-    #     elif dim == 2:
-    #         alpha = alpha[np.newaxis,:,:]
-    #         (nx,ny) = np.shape(alpha)
-    #         alpha = alpha.reshape(1,nx,ny)
-    nz = np.size(alpha, axis=0)
-    sigma = np.zeros(nz)
-    for i in np.arange(nz):
-        sigma[i] = np.median(np.abs(alpha[i] - np.median(alpha[i]))) / 0.6745
-    alpha = np.squeeze(alpha)
+    axes = tuple(range(1, dim))
+    sigma = np.median(np.abs(alpha - np.median(alpha, axis=axes)), axis=axes) / 0.6745
     return sigma
 
 
 def softTh(alpha, thTab, weights=None, reweighted=False):
+    # TODO: remove for loop
     nz = np.size(thTab)
     #     print (weights.shape)
     #     print (thTab.shape)
@@ -147,6 +85,7 @@ def softTh(alpha, thTab, weights=None, reweighted=False):
 
 
 def hardTh(alpha, thTab, weights=None, reweighted=False):
+    # TODO: remove for loop
     nz = np.size(thTab)
     #     print (weights.shape)
     #     print (thTab.shape)

--- a/pycs/sparsity/sparse2d/dct.py
+++ b/pycs/sparsity/sparse2d/dct.py
@@ -170,6 +170,16 @@ def blockdct2d(image, norm="ortho", blocksize=None, overlap=False):
     print(blocksize)
 
     # Compute DCT on sub blocks
+    # TODO: remove the for loops by using module `sliding_window_view` from `numpy.lib.stride_tricks`?
+    # Check the following code:
+    #if overlap:
+    #    block_slices = sliding_window_view(image, (blocksize, blocksize), step=blocksize // 2)
+    #    dct_slices = dct2d(block_slices, norm=norm)
+    #    result[::blocksize // 2, ::blocksize // 2] = dct_slices
+    #else:
+    #    block_slices = sliding_window_view(image, (blocksize, blocksize), step=blocksize)
+    #    dct_slices = dct2d(block_slices, norm=norm)
+    #    result[:n: blocksize, :n: blocksize] = dct_slices
     if overlap:
         for ii in range(2 * n / blocksize - 1):
             for jj in range(2 * n / blocksize - 1):
@@ -227,6 +237,7 @@ def iblockdct2d(image, norm="ortho", blocksize=None, overlap=False):
         This needs MORE TESTING before deployment !
 
     """
+    # TODO: remove the for loops by using module `sliding_window_view` from `numpy.lib.stride_tricks`?
     if norm not in [None, "ortho", "isap"]:
         print("Warning: invalid norm --> using isap")
         norm = "isap"

--- a/pycs/sparsity/sparse2d/dct.py
+++ b/pycs/sparsity/sparse2d/dct.py
@@ -47,16 +47,15 @@ def dct2d(image, norm="ortho"):
     """
     # Check inputs
     image = np.array(image)
-    assert len(image.shape) == 2, "Input image must be 2D."
     assert norm in (None, "ortho", "isap"), "Invalid norm."
 
     # Compute DCT along each axis
     if norm == "isap":
-        result = dct(dct(image, norm="ortho", axis=0), norm="ortho", axis=1)
-        result[:, 0] *= np.sqrt(2)
-        result[0, :] *= np.sqrt(2)
+        result = dct(dct(image, norm="ortho", axis=-2), norm="ortho", axis=-1)
+        result[..., :, 0] *= np.sqrt(2)
+        result[..., 0, :] *= np.sqrt(2)
     else:
-        result = dct(dct(image, norm=norm, axis=0), norm=norm, axis=1)
+        result = dct(dct(image, norm=norm, axis=-2), norm=norm, axis=-1)
 
     return result
 
@@ -88,16 +87,15 @@ def idct2d(image, norm="ortho"):
     """
     # Check inputs
     image = np.array(image)
-    assert len(image.shape) == 2, "Input image must be 2D."
     assert norm in (None, "ortho", "isap"), "Invalid norm."
 
     # Compute inverse DCT along each axis
     if norm == "isap":
-        image[:, 0] /= np.sqrt(2)
-        image[0, :] /= np.sqrt(2)
-        result = idct(idct(image, norm="ortho", axis=0), norm="ortho", axis=1)
+        image[..., :, 0] /= np.sqrt(2)
+        image[..., 0, :] /= np.sqrt(2)
+        result = idct(idct(image, norm="ortho", axis=-2), norm="ortho", axis=-1)
     else:
-        result = idct(idct(image, norm=norm, axis=0), norm=norm, axis=1)
+        result = idct(idct(image, norm=norm, axis=-2), norm=norm, axis=-1)
 
     return result
 

--- a/pycs/sparsity/sparse2d/utils.py
+++ b/pycs/sparsity/sparse2d/utils.py
@@ -25,10 +25,16 @@ def fftconvolve(array, kernel):
     out: array
         the convolved image.
     """
-    x = numpy.fft.fftshift(numpy.fft.fftn(image))
-    y = numpy.fft.fftshift(numpy.fft.fftn(kernel))
+    x = numpy.fft.fftshift(numpy.fft.fft2(image), axes=(-2, -1))
+    y = numpy.fft.fftshift(numpy.fft.fft2(kernel), axes=(-2, -1))
 
-    return numpy.real(numpynp.fft.fftshift(numpy.fft.ifftn(numpy.fft.ifftshift(x * y))))
+    return numpy.real(
+        numpynp.fft.fftshift(
+            numpy.fft.ifft2(
+                numpy.fft.ifftshift(x * y, axes=(-2, -1))
+            ), axes=(-2, -1)
+        )
+    )
 
 
 def fftdeconvolve(image, kernel):
@@ -46,7 +52,15 @@ def fftdeconvolve(image, kernel):
     out: array
         the deconvolved image.
     """
-    x = numpy.fft.fftshift(numpy.fft.fftn(image))
-    y = numpy.fft.fftshift(numpy.fft.fftn(kernel))
+    x = numpy.fft.fftshift(
+        numpy.fft.fft2(image), axes=(-2, -1)
+    )
+    y = numpy.fft.fftshift(
+        numpy.fft.fft2(kernel), axes=(-2, -1)
+    )
 
-    return numpy.real(numpy.fft.fftshift(numpy.fft.ifftn(numpy.fft.ifftshift(x / y))))
+    return numpy.real(
+        numpy.fft.fftshift(
+            numpy.fft.ifft2(numpy.fft.ifftshift(x / y, axes=(-2, -1)))
+        ), axes=(-2, -1)
+    )


### PR DESCRIPTION
Several improvements and optimizations have been made:
- replace for loops by NumPy built-in functions, when possible;
- vectorize mass mapping methods and starlet transform in order to apply them on stacks of images (3D or higher-dimensional arrays) instead of single images;
- remove some code redundancies by creating intermediate functions;
- optimize kappa-to-gamma and gamma-to-kappa conversions (twice faster);
- some bugfixes.