### PR TITLE
Sparse2D v3.0.2

### DIFF
--- a/src/cxx/cmake/BuildSparse2D.cmake
+++ b/src/cxx/cmake/BuildSparse2D.cmake
@@ -3,7 +3,7 @@
 # =================================================#
 
 # Set Sparse2D Version
-set(sparse2dVersion 3.0.1)
+set(sparse2dVersion 3.0.2)
 
 # Download and build Sparse2D
 ExternalProject_Add(sparse2d


### PR DESCRIPTION
Update Sparse2D backend to v3.0.2. This resolves some GMCA bugs that were fixed by @jstarck.